### PR TITLE
Fixed #67: hugo server doesn't work.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ canonifyurls = true
 title = "#学生LT"
 publishdir = "public"
 googleAnalytics = "UA-106772445-1"
+theme = "minimal"
 
 [Params]
 Description="学生エンジニア、集まれ。"


### PR DESCRIPTION
fixed #67 

# 概要
`hugo server`  でビルドエラーを吐く問題を修正

# 変更内容
- `config.toml` に `theme=minimal` を追加

# 補足

これによって、 build.sh と README.md に書いてある、

`--theme=minimal` オプションが不要になるような気がしますが、  
本 Issue の目的とはちょっと別になりそうなのでやってません。